### PR TITLE
fixed /proc not mounted and recursive symlink

### DIFF
--- a/mounter/mount.go
+++ b/mounter/mount.go
@@ -34,13 +34,13 @@ func ResolveRootDir(dir string) (string, error) {
 	}
 
 	if osutil.IsSymlink(dir) {
-		dir, err = os.Readlink(dir)
+		dir, err = fp.EvalSymlinks(dir)
 		if err != nil {
 			return dir, err
 		}
 	}
 
-	return fp.Clean(dir), nil
+	return dir, nil
 }
 
 func (m *Mounter) MountSysProc() error {

--- a/mounter/mount.go
+++ b/mounter/mount.go
@@ -45,7 +45,7 @@ func ResolveRootDir(dir string) (string, error) {
 
 func (m *Mounter) MountSysProc() error {
 	// mount -t proc proc {{rootDir}}/proc
-	if err := mount.Mount("proc", fp.Join(m.rootDir, "/proc"), "proc", "remount"); err != nil {
+	if err := osutil.MountIfNotMounted("proc", fp.Join(m.rootDir, "/proc"), "proc", ""); err != nil {
 		return errors.Errorf("Failed to mount /proc: %s", err)
 	}
 	// mount --rbind /sys {{rootDir}}/sys


### PR DESCRIPTION
日本語で失礼します。

### /procがマウントされない

imageを準備
```
$ sudo docker images | grep ubuntu | grep latest
ubuntu                  latest              ebcd9d4fca80        8 weeks ago         118 MB
$ sudo droot export ubuntu:latest | gzip -cq > ubuntu.tar.gz
$ sudo mkdir -p /tmp/ubuntu
$ sudo tar zxvf ubuntu.tar.gz -C /tmp/ubuntu
```

droot実行
```
# droot -v
droot version 0.7.4
# droot run --cp --root /tmp/ubuntu -- ls
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
# df -ha | grep ubuntu
sysfs              0     0     0    - /tmp/ubuntu/sys
securityfs         0     0     0    - /tmp/ubuntu/sys/kernel/security
tmpfs           2.0G     0  2.0G   0% /tmp/ubuntu/sys/fs/cgroup
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/systemd
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/cpuset
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/cpu,cpuacct
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/devices
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/freezer
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/net_cls,net_prio
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/blkio
cgroup             0     0     0    - /tmp/ubuntu/sys/fs/cgroup/perf_event
pstore             0     0     0    - /tmp/ubuntu/sys/fs/pstore
debugfs            0     0     0    - /tmp/ubuntu/sys/kernel/debug
# droot run --cp --root /tmp/ubuntu -- ps aufx
Error, do this: mount -t proc proc /proc
```

https://github.com/yuuki/droot/blob/95362df0c89afbd695be4f8c38ea91d60f64581b/mounter/mount.go#L48
```go
if err := mount.Mount("proc", fp.Join(m.rootDir, "/proc"), "proc", "remount"); err != nil {
```
呼び出し先の処理を見ると単に "remount" だけではマウントされないようでした。
https://github.com/yuuki/droot/blob/5ba3977b5af420b937e59f23947bc90de7714749/vendor/github.com/docker/docker/pkg/mount/mounter_linux.go#L30-L52

ここは修正前の `osutil.MountIfNotMounted`を利用するコードに戻しました。


### 多重シンボリックリンクが解決されない
`os.Readlink` では多重シンボリックリンクを最後まで解決しません。
ResolveRootDir関数から得られたrootDir文字列が実際のmount済み情報と一致しないため、Mounted関数が期待する挙動になってなさそうでした。
なので、最後まで解決するように修正しました。