### PR TITLE
Change go version to latest in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.15
 RUN go get  github.com/laher/goxc
 ENV USER root
 WORKDIR /go/src/github.com/yuuki/droot


### PR DESCRIPTION
Since current codes depends go mod to build, the current Dockerfile's go version have no go mod support.